### PR TITLE
Configure Vite to strip console.log in production

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import vue from '@vitejs/plugin-vue'
 import VueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [vue(), VueDevTools()],
   resolve: {
     alias: {
@@ -14,5 +14,8 @@ export default defineConfig({
   },
   build: {
     sourcemap: true
+  },
+  esbuild: {
+    drop: mode === 'production' ? ['console', 'debugger'] : []
   }
-})
+}))


### PR DESCRIPTION
## Summary
- Configure esbuild `drop` option to automatically remove `console.log` and `debugger` statements from production builds
- Uses Vite's function config pattern to conditionally apply only in production mode
- Keeps console statements available during development for debugging

## Test plan
- [x] Verified production build completes successfully
- [x] Verified no console statements present in minified output (grep returns 0 matches)
- [ ] Test dev server still shows console output

🤖 Generated with [Claude Code](https://claude.com/claude-code)