### PR TITLE
Fix vitest config to avoid mergeConfig error

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,26 +1,24 @@
 import { fileURLToPath } from 'node:url'
-import { defineConfig, mergeConfig } from 'vitest/config'
-import viteConfig from './vite.config.js'
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
 
-export default mergeConfig(
-  viteConfig,
-  defineConfig({
-    test: {
-      environment: 'happy-dom',
-      globals: true,
-      include: ['tests/**/*.{test,spec}.{js,ts}'],
-      coverage: {
-        provider: 'v8',
-        reporter: ['text', 'json', 'html'],
-        include: ['src/**/*.{js,vue}'],
-        exclude: ['src/main.js', 'src/assets/**']
-      },
-      setupFiles: ['tests/setup.js']
-    },
-    resolve: {
-      alias: {
-        '@': fileURLToPath(new URL('./src', import.meta.url))
-      }
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
     }
-  })
-)
+  },
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+    include: ['tests/**/*.{test,spec}.{js,ts}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.{js,vue}'],
+      exclude: ['src/main.js', 'src/assets/**']
+    },
+    setupFiles: ['tests/setup.js']
+  }
+})


### PR DESCRIPTION
## Summary
- Made `vitest.config.js` standalone instead of merging with `vite.config.js`
- The merge was failing because `vite.config.js` uses a callback form (`defineConfig(({ mode }) => ...)`) for production console stripping, which `mergeConfig` cannot handle
- Vitest config now includes the necessary shared config (Vue plugin, path alias) directly
- Tests don't need the production esbuild settings anyway

## Test plan
- [x] Verify `npm run test:run` passes (47 tests)
- [x] Verify `npm run build` still works
- [ ] Verify `npm run test:coverage` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)